### PR TITLE
Regex refinement

### DIFF
--- a/src/compare.js
+++ b/src/compare.js
@@ -12,7 +12,7 @@ const removeStopWords = (textArray, stopArray) => {
   var properCaseArray = _.map(resultArray, o => {
     return _.capitalize(o);
   });
-  return properCaseArray;
+  return properCaseArray; //returning capitalized words for a better display.
 };
 
 module.exports = { removeStopWords };

--- a/src/compare.test.js
+++ b/src/compare.test.js
@@ -8,6 +8,6 @@ describe("Tests for compare arrays function", () => {
     expect(compare.removeStopWords(testArray1, testArray2)).toEqual(
       expect.arrayContaining(resultArray1)
     );
-    //console.log(compare.removeStopWords(testArray1, testArray2));3
+    //console.log(compare.removeStopWords(testArray1, testArray2));
   });
 });

--- a/src/countWords.js
+++ b/src/countWords.js
@@ -17,6 +17,7 @@ const count = textArray => {
   //Goal to have old array mutated to remove head and any matches.
   //And have function return new array of same words.
   //Store that word and a newWordArry.length in the object.
+  //Idea for future improvement. Try sorting the array first to improve performance.
 };
 
 module.exports = { count };

--- a/src/fileReader.test.js
+++ b/src/fileReader.test.js
@@ -3,17 +3,17 @@ const fileReader = require("./fileReader.js");
 describe("Tests for file reader", () => {
   it("mobydick.txt read and returned as array of words.", () => {
     const testArray1 = ["Moby", "Dick"];
-    expect(fileReader.read("mobydick.txt", /[^a-zA-Z0-9\_\’\'\-]|\s/)).toEqual(
-      expect.arrayContaining(testArray1)
-    );
+    expect(
+      fileReader.read("mobydick.txt", /[^a-zA-Z0-9\_\'\-\’]|(?<!\w)’|\s/)
+    ).toEqual(expect.arrayContaining(testArray1));
   });
   it("mobydick.txt read and not returning array of phrases.", () => {
     const testArray1 = [
       "public domain works in creating the Project Gutenberg-tm collection"
     ];
-    expect(fileReader.read("mobydick.txt", /[^a-zA-Z0-9\_\’\'\-]|\s/)).toEqual(
-      expect.not.arrayContaining(testArray1)
-    );
+    expect(
+      fileReader.read("mobydick.txt", /[^a-zA-Z0-9\_\'\-\’]|(?<!\w)’|\s/)
+    ).toEqual(expect.not.arrayContaining(testArray1));
   });
   it("stop-words.txt read and returned as array of words.", () => {
     const testArray1 = ["about", "did", "you"];

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ const _ = require("lodash");
 
 var mobyArray = fileReader.read(
   "../data/mobydick.txt",
-  /[^a-zA-Z0-9\_\’\'\-]|\s/
+  /[^a-zA-Z0-9\_\'\-\’]|(?<!\w)’|\s/
 );
 var stopArray = fileReader.read(
   "../data/stop-words.txt",

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -4,6 +4,8 @@ const countWords = require("./countWords.js");
 const sortWords = require("./sortWords.js");
 
 describe("Tests for index js file", () => {
+  //Red test 1 and Green test 1 were created at the start of the project
+  //to make sure I had Jest set up and running correctly.
   //  it("Red test 1. Make sure test framework returns failure.", () => {
   //    expect(3).toEqual(2);
   //  });

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -21,7 +21,7 @@ describe("Tests for index js file", () => {
   it("Test getting an array of counted word objects", () => {
     var mobyArray = fileReader.read(
       "../data/mobydick.txt",
-      /[^a-zA-Z0-9\_\’\'\-]|\s/
+      /[^a-zA-Z0-9\_\'\-\’]|(?<!\w)’|\s/
     );
     var stopArray = fileReader.read(
       "../data/stop-words.txt",


### PR DESCRIPTION
I found the regex secret sauce to keep "goin'" as a word with the apostrophe. But not get the apostrophe from: 
“‘Stern all!’ exclaimed the mate, as upon turning his head, he saw
the distended jaws of a large Sperm Whale close to the head of the
boat, threatening it with instant destruction;—‘Stern all, for your
lives!’” —Wharton the Whale Killer.
both the "all!'" and "lives!'" have different patterns. the key is that they are both not preceded by a letter.